### PR TITLE
Feature/1133 fix deprecated refs

### DIFF
--- a/app/models/jellyfish_demo/product/server.rb
+++ b/app/models/jellyfish_demo/product/server.rb
@@ -1,0 +1,14 @@
+module JellyfishDemo
+  module Product
+    class Server < ::Product
+      def order_questions
+        [
+        ]
+      end
+
+      def service_class
+        'JellyfishDemo::Service::Server'.constantize
+      end
+    end
+  end
+end

--- a/app/models/jellyfish_demo/product/sql.rb
+++ b/app/models/jellyfish_demo/product/sql.rb
@@ -1,0 +1,14 @@
+module JellyfishDemo
+  module Product
+    class SQL < ::Product
+      def order_questions
+        [
+        ]
+      end
+
+      def service_class
+        'JellyfishDemo::Service::SQL'.constantize
+      end
+    end
+  end
+end

--- a/app/models/jellyfish_demo/product/widget.rb
+++ b/app/models/jellyfish_demo/product/widget.rb
@@ -1,0 +1,15 @@
+module JellyfishDemo
+  module Product
+    class Widget < ::Product
+      def order_questions
+        [
+          { name: :environment, value_type: :string, field: :environments, required: true }
+        ]
+      end
+
+      def service_class
+        'JellyfishDemo::Service::Widget'.constantize
+      end
+    end
+  end
+end

--- a/app/models/jellyfish_demo/product_type/server.rb
+++ b/app/models/jellyfish_demo/product_type/server.rb
@@ -31,13 +31,8 @@ module JellyfishDemo
         ]
       end
 
-      def order_questions
-        [
-        ]
-      end
-
-      def service_class
-        'JellyfishDemo::Service::Server'.constantize
+      def product_class
+        'JellyfishDemo::Product::Server'.constantize
       end
     end
   end

--- a/app/models/jellyfish_demo/product_type/sql.rb
+++ b/app/models/jellyfish_demo/product_type/sql.rb
@@ -30,13 +30,8 @@ module JellyfishDemo
         ]
       end
 
-      def order_questions
-        [
-        ]
-      end
-
-      def service_class
-        'JellyfishDemo::Service::SQL'.constantize
+      def product_class
+        'JellyfishDemo::Product::SQL'.constantize
       end
     end
   end

--- a/app/models/jellyfish_demo/product_type/widget.rb
+++ b/app/models/jellyfish_demo/product_type/widget.rb
@@ -6,7 +6,7 @@ module JellyfishDemo
 
         transaction do
           [
-            set('Demo Widget', '95244eb2-3286-43ec-915b-e8aedfd23bd2', provider_type: 'JellyfishDemo::Provider::Demo', active: 'false')
+              set('Demo Widget', '95244eb2-3286-43ec-915b-e8aedfd23bd2', provider_type: 'JellyfishDemo::Provider::Demo', active: 'false')
           ].each do |s|
             create! s.merge!(type: 'JellyfishDemo::ProductType::Widget')
           end
@@ -23,17 +23,11 @@ module JellyfishDemo
 
       def product_questions
         [
-          { name: :environment, value_type: :string, field: :environments, required: true }
         ]
       end
 
-      def order_questions
-        [
-        ]
-      end
-
-      def service_class
-        'JellyfishDemo::Service::Widget'.constantize
+      def product_class
+        'JellyfishDemo::Product::Widget'.constantize
       end
     end
   end

--- a/app/models/jellyfish_demo/product_type/widget.rb
+++ b/app/models/jellyfish_demo/product_type/widget.rb
@@ -6,7 +6,7 @@ module JellyfishDemo
 
         transaction do
           [
-              set('Demo Widget', '95244eb2-3286-43ec-915b-e8aedfd23bd2', provider_type: 'JellyfishDemo::Provider::Demo', active: 'false')
+            set('Demo Widget', '95244eb2-3286-43ec-915b-e8aedfd23bd2', provider_type: 'JellyfishDemo::Provider::Demo', active: 'false')
           ].each do |s|
             create! s.merge!(type: 'JellyfishDemo::ProductType::Widget')
           end

--- a/lib/tasks/jellyfish_demo_tasks.rake
+++ b/lib/tasks/jellyfish_demo_tasks.rake
@@ -55,7 +55,7 @@ namespace :setup do
       provider = providers.assoc(data.delete 'provider').last
       data.merge! product_type: product_type, provider: provider
       puts "  #{data['name']}"
-      [data.delete('_assoc'), Product.create(data).tap do |product|
+      [data.delete('_assoc'), data[:product_type].product_class.create(data).tap do |product|
         product.answers.create(answers) unless answers.nil?
       end]
     end


### PR DESCRIPTION
Move `order_questions` and `service_class` to Product classes from ProductType.

Addresses https://github.com/boozallen/projectjellyfish/issues/1133. 
